### PR TITLE
raspberrypi4-64: Add support to the 64-bit variant

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -114,6 +114,12 @@ IMAGE_BOOT_FILES_updatehub-rpi_raspberrypi4 ??= " \
     boot.scr-${MACHINE};boot.scr \
 "
 
+# UpdateHub settings for raspberrypi4-64 machine
+MACHINEOVERRIDES_prepend_raspberrypi4-64 = "updatehub-rpi:"
+
+KERNEL_IMAGETYPE_UBOOT_updatehub-rpi_raspberrypi4-64 ??= "Image"
+UHUPKG_FILES_updatehub-rpi_raspberrypi4-64 ??= "raspberrypi4.uhupkg"
+
 ###
 # Configuration for Raspberry Pi Devices
 #

--- a/recipes-bsp/u-boot/u-boot/raspberrypi4-64/ARM-raspberrypi-Add-support-for-Raspberry-Pi-64-bits.patch
+++ b/recipes-bsp/u-boot/u-boot/raspberrypi4-64/ARM-raspberrypi-Add-support-for-Raspberry-Pi-64-bits.patch
@@ -1,0 +1,43 @@
+From 169af7cd70880cd6471bc59acead6060e98f12fa Mon Sep 17 00:00:00 2001
+From: Fabio Berton <fabio.berton@ossystems.com.br>
+Date: Thu, 2 Jan 2020 15:35:15 -0300
+Subject: [PATCH] ARM: raspberrypi: Add support for Raspberry Pi 64 bits
+Organization: O.S. Systems Software LTDA.
+
+Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
+---
+ include/configs/rpi.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index b4e711cb0e..85d31f44ef 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -84,13 +84,13 @@
+  * UpdateHub configuration
+  */
+ 
+-#define UPDATEHUB_LOAD_OS_A     "load mmc 0:2 ${kernel_addr_r} /boot/zImage; " \
++#define UPDATEHUB_LOAD_OS_A     "load mmc 0:2 ${kernel_addr_r} /boot/Image; " \
+                                 "load mmc 0:2 ${fdt_addr_r} /boot/${fdtfile}; " \
+                                 "fdt addr ${fdt_addr_r} && " \
+                                 "fdt get value bootargs_dtb /chosen bootargs;"
+ #define UPDATEHUB_FIND_ROOT_A   "part uuid mmc 0:2 uuid"
+ 
+-#define UPDATEHUB_LOAD_OS_B     "load mmc 0:3 ${kernel_addr_r} /boot/zImage; " \
++#define UPDATEHUB_LOAD_OS_B     "load mmc 0:3 ${kernel_addr_r} /boot/Image; " \
+                                 "load mmc 0:3 ${fdt_addr_r} /boot/${fdtfile}; " \
+                                 "fdt addr ${fdt_addr_r} && " \
+                                 "fdt get value bootargs_dtb /chosen bootargs;"
+@@ -98,7 +98,7 @@
+ 
+ #define UPDATEHUB_BOOTARGS      "${bootargs_dtb} root=PARTUUID=${uuid} rootwait rw " \
+                                 "console=ttyS0,115200"
+-#define UPDATEHUB_BOOTCMD       "bootz ${kernel_addr_r} - ${fdt_addr_r}"
++#define UPDATEHUB_BOOTCMD       "booti ${kernel_addr_r} - ${fdt_addr_r}"
+ 
+ #include <configs/updatehub-common.h>
+ 
+-- 
+2.24.1
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -7,3 +7,4 @@ SRC_URI_append_updatehub-rpi = "\
 "
 
 SRC_URI_append_updatehub-rpi_raspberrypi3-64 += "file://ARM-raspberrypi-Add-support-for-Raspberry-Pi-64-bits.patch"
+SRC_URI_append_updatehub-rpi_raspberrypi4-64 += "file://ARM-raspberrypi-Add-support-for-Raspberry-Pi-64-bits.patch"


### PR DESCRIPTION
This adds support to the 64-bit variant of Raspberry Pi 4 board, mostly reusing
what we did for the 3 version.

Fixes: #9.
Reported-by: Filippo Guerzoni <filippo.guerzoni@gmail.com>
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>