### PR TITLE
cicd: backport: Fix events allowing the workflow to run

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -2,23 +2,13 @@ name: Backport labeled merged pull requests
 on:
   pull_request_target:
     types: [closed]
-  issue_comment:
-    types: [created]
 jobs:
   build:
     name: Create backport PRs
     runs-on: ubuntu-latest
     # Only run when pull request is merged
     # or when a comment containing `/backport` is created
-    if: >
-      (
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request_target.merged
-      ) || (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request_target &&
-        contains(github.event.comment.body, '/backport')
-      )
+    if: github.event.pull_request.merged
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Even when using pull_request_target, the merged is issued as
pull_request and this should be used to ensure we can run the workflow.

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>